### PR TITLE
Promote to prod environment

### DIFF
--- a/components/java-springboot-rddlwthu/overlays/prod/deployment-patch.yaml
+++ b/components/java-springboot-rddlwthu/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/java-springboot-rddlwthu:github-20069ce657181e85edac9b8b45980c9da4a426ab
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/java-springboot-rddlwthu:github-20069ce657181e85edac9b8b45980c9da4a426ab